### PR TITLE
feat: update OpenGraph image to use sunset.webp as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,21 +85,25 @@ Images should be placed in `src/assets/` for optimization or `public/` for direc
 This blog automatically generates OpenGraph meta tags for better social media sharing:
 
 ### How It Works
+
 - **Default image**: `sunset.webp` is used as the fallback OpenGraph image
 - **Blog posts**: Use their `heroImage` from frontmatter for social previews
 - **Pages**: Use their `heroImage` from frontmatter, or fall back to default
 
 ### Adding OpenGraph Images
+
 1. **For blog posts**: Add `heroImage: "../../assets/your-image.webp"` to frontmatter
 2. **For pages**: Add `heroImage: ../assets/your-image.webp` to frontmatter
 3. **Change default**: Update `FallbackImage` import in `src/components/BaseHead.astro`
 
 ### Testing Social Previews
+
 - **Facebook**: [Sharing Debugger](https://developers.facebook.com/tools/debug/)
 - **Twitter**: [Card Validator](https://cards-dev.twitter.com/validator)
 - **LinkedIn**: [Post Inspector](https://www.linkedin.com/post-inspector/)
 
 ### Optimal Image Sizes
+
 - OpenGraph images work best at **1200×630px** (1.91:1 ratio)
 - Minimum size: 600×315px
 - Maximum file size: Keep under 1MB for best performance

--- a/README.md
+++ b/README.md
@@ -73,11 +73,36 @@ For optimal display and performance, use these recommended image dimensions:
 | ------------------------- | ---------- | ------------ | ---------------------------- |
 | Blog header images (hero) | 960×480px  | 2:1          | Individual blog post headers |
 | Blog list thumbnails      | 960×480px  | 2:1          | Blog listing page thumbnails |
+| OpenGraph/Social sharing  | 1200×630px | 1.91:1       | Social media previews        |
 | Page content width        | 960px max  | -            | Main content container       |
 
 _Note: These dimensions match the blog-placeholder images included with the template. The Astro Image component will automatically resize and optimize images as needed._
 
 Images should be placed in `src/assets/` for optimization or `public/` for direct serving without processing.
+
+## 🌐 OpenGraph & Social Sharing
+
+This blog automatically generates OpenGraph meta tags for better social media sharing:
+
+### How It Works
+- **Default image**: `sunset.webp` is used as the fallback OpenGraph image
+- **Blog posts**: Use their `heroImage` from frontmatter for social previews
+- **Pages**: Use their `heroImage` from frontmatter, or fall back to default
+
+### Adding OpenGraph Images
+1. **For blog posts**: Add `heroImage: "../../assets/your-image.webp"` to frontmatter
+2. **For pages**: Add `heroImage: ../assets/your-image.webp` to frontmatter
+3. **Change default**: Update `FallbackImage` import in `src/components/BaseHead.astro`
+
+### Testing Social Previews
+- **Facebook**: [Sharing Debugger](https://developers.facebook.com/tools/debug/)
+- **Twitter**: [Card Validator](https://cards-dev.twitter.com/validator)
+- **LinkedIn**: [Post Inspector](https://www.linkedin.com/post-inspector/)
+
+### Optimal Image Sizes
+- OpenGraph images work best at **1200×630px** (1.91:1 ratio)
+- Minimum size: 600×315px
+- Maximum file size: Keep under 1MB for best performance
 
 ## 📁 Asset Management
 

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -3,7 +3,7 @@
 // all pages through the use of the <BaseHead /> component.
 import "../styles/global.css";
 import type { ImageMetadata } from "astro";
-import FallbackImage from "../assets/blog-placeholder-1.jpg";
+import FallbackImage from "../assets/sunset.webp";
 import { SITE_TITLE } from "../consts";
 
 interface Props {

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -13,7 +13,7 @@ const { title, description, pubDate, updatedDate, heroImage } = Astro.props;
 
 <html lang="en">
   <head>
-    <BaseHead title={title} description={description} />
+    <BaseHead title={title} description={description} image={heroImage} />
     <style>
       main {
         width: calc(100% - 2em);

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -13,12 +13,12 @@ const dateObj = new Date(pubDate);
 const updatedDateObj = updatedDate ? new Date(updatedDate) : undefined;
 
 // Import the hero image if it exists
-let heroImageSrc;
+let processedImage;
 if (heroImage) {
   try {
     const images = import.meta.glob("../assets/*", { eager: true });
     const imagePath = `../assets/${heroImage.split("/").pop()}`;
-    heroImageSrc = images[imagePath]?.default;
+    processedImage = images[imagePath]?.default;
   } catch (_e) {
     console.warn("Could not load hero image:", heroImage);
   }
@@ -27,7 +27,7 @@ if (heroImage) {
 
 <html lang="en">
   <head>
-    <BaseHead title={title} description={description} image={heroImageSrc} />
+    <BaseHead title={title} description={description} image={processedImage} />
     <style>
       main {
         width: calc(100% - 2em);
@@ -75,8 +75,8 @@ if (heroImage) {
       <article>
         <div class="hero-image">
           {
-            heroImageSrc && (
-              <Image width={1020} height={510} src={heroImageSrc} alt="" />
+            processedImage && (
+              <Image width={1020} height={510} src={processedImage} alt="" />
             )
           }
         </div>

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -27,7 +27,7 @@ if (heroImage) {
 
 <html lang="en">
   <head>
-    <BaseHead title={title} description={description} />
+    <BaseHead title={title} description={description} image={heroImageSrc} />
     <style>
       main {
         width: calc(100% - 2em);


### PR DESCRIPTION
## Summary
- Updates the default OpenGraph fallback image from placeholder to sunset.webp
- Enables individual blog posts and pages to use their heroImages for social sharing
- Adds comprehensive OpenGraph documentation to README with testing tools and best practices

## Changes Made
- **BaseHead.astro**: Changed fallback image import from `blog-placeholder-1.jpg` to `sunset.webp`
- **BlogPost.astro**: Now passes `heroImage` prop to BaseHead component
- **PageLayout.astro**: Now passes `heroImageSrc` prop to BaseHead component  
- **README.md**: Added detailed OpenGraph section with:
  - How the system works
  - How to add/change images
  - Social media testing tools
  - Optimal image dimensions (1200×630px for OpenGraph)

## Testing
- ✅ Built site and verified OpenGraph meta tags in generated HTML
- ✅ Homepage uses sunset.webp as default
- ✅ Blog posts use their individual heroImages (e.g., dolphin.webp for hello-world)
- ✅ About page uses sunset.webp from its heroImage
- ✅ Fallback works for posts without heroImages

## Benefits
- Better social media previews with beautiful sunset image instead of generic placeholder
- Individual posts can have unique social sharing images
- Clear documentation for future maintenance and updates
- Follows social media best practices for image dimensions